### PR TITLE
Add simple escape markdown symbols

### DIFF
--- a/src/Seq.App.Telegram/MessageFormatter.cs
+++ b/src/Seq.App.Telegram/MessageFormatter.cs
@@ -12,6 +12,14 @@ namespace Seq.App.Telegram
     {
         static readonly Regex PlaceholdersRegex = new Regex("(\\[(?<key>[^\\[\\]]+?)(\\:(?<format>[^\\[\\]]+?))?\\])", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+        static readonly Dictionary<string, string> EscapeList = new Dictionary<string, string>
+        {
+            { "_", "\\_" },
+            { "*", "\\*" },
+            { "[", "\\[" },
+            { "`", "\\`" }
+        };
+
         public MessageFormatter(ILogger log, string baseUrl, string messageTemplate)
         {
             Log = log;
@@ -52,6 +60,11 @@ namespace Seq.App.Telegram
         string FormatValue(object value, string format)
         {
             var rawValue = value?.ToString() ?? "(Null)";
+
+            foreach (var escape in EscapeList)
+            {
+                rawValue = rawValue.Replace(escape.Key, escape.Value);
+            }
 
             if (string.IsNullOrWhiteSpace(format))
                 return rawValue;


### PR DESCRIPTION
Hello, I am getting this kind of error in Seg. the message that triggered the alert had characters that are perceived by the telegram as characters for markdown control. 

Seq.App.Telegram error
![изображение](https://user-images.githubusercontent.com/31487230/129035759-14f7edb0-8c40-4f37-ad6d-a74b4d1ddee0.png)

the error that should have been sent to the telegram 
![изображение](https://user-images.githubusercontent.com/31487230/129036274-14773bc9-4aeb-4eaa-acc1-0c828cb6eb4a.png)

I added the simplest escaping, but it would be enough for me already 
